### PR TITLE
Allow file-prefix configuration parameter to be set via environment variable

### DIFF
--- a/src/main/java/com/hivemq/plugin/configuration/Configuration.java
+++ b/src/main/java/com/hivemq/plugin/configuration/Configuration.java
@@ -70,14 +70,14 @@ public class Configuration {
     public String getFilePrefix() {
         final String property;
 
-        if (System.getenv("S3_DISCOVERY_FILE_PREFIX") != null) {
-            property = System.getenv("S3_DISCOVERY_FILE_PREFIX");
+        if (System.getenv("S3_FILE_PREFIX") != null) {
+            property = System.getenv("S3_FILE_PREFIX");
         } else if (getProperty("file-prefix") != null) {
             property = getProperty("file-prefix");
         } else {
             property = "";
         }
-        
+
         return property;
     }
 

--- a/src/main/java/com/hivemq/plugin/configuration/Configuration.java
+++ b/src/main/java/com/hivemq/plugin/configuration/Configuration.java
@@ -68,10 +68,16 @@ public class Configuration {
     }
 
     public String getFilePrefix() {
-        final String property = getProperty("file-prefix");
-        if (property == null) {
-            return "";
+        final String property;
+
+        if (System.getenv("S3_DISCOVERY_FILE_PREFIX") != null) {
+            property = System.getenv("S3_DISCOVERY_FILE_PREFIX");
+        } else if (getProperty("file-prefix") != null) {
+            property = getProperty("file-prefix");
+        } else {
+            property = "";
         }
+        
         return property;
     }
 


### PR DESCRIPTION
In a containerized deployment environment where the server configuration is intended to be immutably baked into an image, e.g. docker, the current configuration mechanics (the `s3discovery.properties` file) do not allow the `file-prefix` parameter to differ between deployments. Hence, it's not currently possible to use the same image for multiple separate clusters.

This PR allows the `file-prefix` parameter to be set by the `S3_FILE_PREFIX` environment variable. This enables the prefix to be set without changing the configuration file and rebuilding the container image.