### PR TITLE
Add property to use path style access

### DIFF
--- a/src/main/java/com/hivemq/plugin/callbacks/S3DiscoveryCallback.java
+++ b/src/main/java/com/hivemq/plugin/callbacks/S3DiscoveryCallback.java
@@ -1,6 +1,7 @@
 package com.hivemq.plugin.callbacks;
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.S3ClientOptions;
 import com.amazonaws.services.s3.model.*;
 import com.amazonaws.util.StringInputStream;
 import com.google.common.io.BaseEncoding;
@@ -46,6 +47,7 @@ public class S3DiscoveryCallback implements ClusterDiscoveryCallback {
                                final PluginExecutorService pluginExecutorService) {
         this.s3 = s3;
         this.s3.setEndpoint(configuration.getEndpoint());
+        this.s3.setS3ClientOptions(new S3ClientOptions().withPathStyleAccess(configuration.withPathStyleAccess()));
         this.configuration = configuration;
         this.pluginExecutorService = pluginExecutorService;
         this.bucketName = configuration.getBucketName();

--- a/src/main/java/com/hivemq/plugin/configuration/Configuration.java
+++ b/src/main/java/com/hivemq/plugin/configuration/Configuration.java
@@ -145,6 +145,10 @@ public class Configuration {
         return property;
     }
 
+    public boolean withPathStyleAccess() {
+        return Boolean.parseBoolean(getProperty("s3-path-style-access"));
+    }
+
     private String getProperty(final String key) {
         if (properties == null) {
             return null;


### PR DESCRIPTION
When using a custom endpoint there may be problems with using non path style access. Therefore a configuration property was added to configure if path style should be used.